### PR TITLE
cmake: add openmp flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ find_package(OpenGL)
 find_package(PkgConfig)
 pkg_check_modules(GLFW REQUIRED glfw3)
 
+find_package(OpenMP)
+if (OPENMP_FOUND)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif()
+
 add_definitions(-std=c++11 -Wall -O3 -march=native -g)
 
 add_subdirectory(src)


### PR DESCRIPTION
This will add '-fopenmp' to  both compile and link flags.